### PR TITLE
[FEAT][#76]: manual timeline item step3 입력 반영 지원

### DIFF
--- a/src/ansimon_ai/timeline/types.py
+++ b/src/ansimon_ai/timeline/types.py
@@ -73,6 +73,7 @@ class TimelineEvidenceItem(BaseModel):
     title: str
     description: str
     tags: List[TimelineTagType]
+    is_ai_original: bool = True
     referenced_evidence_count: int = 1
     referenced_evidence_ids: List[UUID] = Field(default_factory=list)
 

--- a/src/ansimon_ai/writing/build_input.py
+++ b/src/ansimon_ai/writing/build_input.py
@@ -32,8 +32,7 @@ def build_complaint_writing_input(
                                 title=evidence.title,
                                 description=evidence.description,
                                 tags=list(evidence.tags),
-                                # Prototype timeline items are currently AI-generated.
-                                is_ai_original=True,
+                                is_ai_original=evidence.is_ai_original,
                                 referenced_evidence_ids=list(
                                     evidence.referenced_evidence_ids
                                 ),

--- a/src/schemas/complaint_timeline.py
+++ b/src/schemas/complaint_timeline.py
@@ -29,6 +29,7 @@ class TimelineEvidence(BaseModel):
     title: str
     description: str
     tags: List[TagType]
+    is_ai_original: bool = True
     referenced_evidence_count: int
     referenced_evidence_ids: List[UUID]
 

--- a/src/schemas/timeline_inputs.py
+++ b/src/schemas/timeline_inputs.py
@@ -76,6 +76,7 @@ class TimelineEvidenceItem(BaseModel):
     title: str
     description: str
     tags: List[TimelineTagType]
+    is_ai_original: bool = True
     referenced_evidence_count: int
     referenced_evidence_ids: List[UUID] = Field(default_factory=list)
 

--- a/tests/writing/test_manual_item_build_input.py
+++ b/tests/writing/test_manual_item_build_input.py
@@ -1,0 +1,40 @@
+from uuid import uuid4
+
+from ansimon_ai.timeline.types import TimelineDateItem, TimelineEvent, TimelineEvidenceItem
+from ansimon_ai.writing.build_input import build_complaint_writing_input
+
+def test_build_complaint_writing_input_preserves_manual_item_flag() -> None:
+    complaint_id = uuid4()
+
+    timeline_items = [
+        TimelineDateItem(
+            date="2026-02-18",
+            events=[
+                TimelineEvent(
+                    time="17:00",
+                    evidences=[
+                        TimelineEvidenceItem(
+                            timeline_evidence_id=uuid4(),
+                            index=1,
+                            title="퇴근길 접근 시도",
+                            description="퇴근길 편의점 앞에서 피고소인이 직접 접근을 시도하였고, 고소인은 주변에 도움을 요청하였다.",
+                            tags=["physical", "threat"],
+                            is_ai_original=False,
+                            referenced_evidence_ids=[],
+                        )
+                    ],
+                )
+            ],
+        )
+    ]
+
+    result = build_complaint_writing_input(
+        complaint_id=complaint_id,
+        timeline_items=timeline_items,
+        evidence_results=[],
+    )
+
+    evidence = result.items[0].events[0].evidences[0]
+    assert evidence.title == "퇴근길 접근 시도"
+    assert evidence.is_ai_original is False
+    assert evidence.referenced_evidence_ids == []


### PR DESCRIPTION
## 작업 내용
> step2에서 사용자가 직접 추가한 manual timeline item이 step3 문서 작성 입력에도 반영될 수 있도록 timeline 스키마와 변환 로직을 수정했습니다.

기존에는 step3 문서 작성 input 변환 과정에서 timeline item이 모두 AI 생성 항목으로 간주되어 `is_ai_original=True`로 고정 처리되고 있었습니다.
이번 PR에서는 final timeline item에 manual 구분 필드를 추가하고, step3 입력 변환 시 해당 값을 그대로 반영하도록 수정했습니다.

**주요 작업**
- timeline item 스키마에 `is_ai_original` 필드 추가
- step3 입력 변환 함수에서 `is_ai_original=True` 고정 제거
- manual item 케이스 테스트 추가

**manual item 반영 기준**
- `title`: 사용자 입력 제목
- `description`: 사용자 입력 `situation`이 있으면 해당 값, 없으면 비움
- `tags`: 사용자 입력 태그
- `is_ai_original`: `False`
- `referenced_evidence_ids`: 연결된 증거가 있으면 반영, 없으면 빈 배열

## 이슈 번호
#76 

## 스크린샷 (선택)
N/A

## 참고 사항
- manual item의 증거자료는 현재 기준으로 AI 재분석 대상이 아니라 연결된 첨부 증거로 보는 방향입니다.