### PR TITLE
[FEAT][#79]: step1-step2 증거 증분 분석 및 캐시 재사용 적용

### DIFF
--- a/src/ansimon_ai/structuring/cache/hash.py
+++ b/src/ansimon_ai/structuring/cache/hash.py
@@ -28,7 +28,7 @@ def compute_input_hash(
 ) -> str:
     # Ensure the payload is JSON-serializable (Pydantic models -> plain dicts)
     base_payload = {
-        **struct_input.model_dump(),
+        **struct_input.model_dump(mode="json"),
         "schema_version": schema_version,
         "prompt_version": prompt_version,
     }

--- a/src/ansimon_ai/timeline/prototype.py
+++ b/src/ansimon_ai/timeline/prototype.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import hashlib
 import json
 import shutil
 from collections.abc import Callable
@@ -101,6 +102,7 @@ def process_single_evidence(
         return _process_victim_evidence(
             evidence,
             llm_client=llm_client,
+            cache=cache,
             frame_interval_seconds=victim_video_frame_interval_seconds,
         )
 
@@ -249,6 +251,7 @@ def _process_victim_evidence(
     evidence: TimelinePrototypeEvidenceInput,
     *,
     llm_client,
+    cache: Optional[object] = None,
     frame_interval_seconds: int = 3,
 ) -> EvidenceProcessingResult:
     if evidence.file_format not in {"IMAGE", "VIDEO"}:
@@ -271,12 +274,23 @@ def _process_victim_evidence(
 
     temp_dir = _create_runtime_temp_dir(evidence)
     try:
-        if evidence.file_format == "IMAGE":
+        cache_key = _compute_victim_cache_key(
+            evidence,
+            default_frame_interval_seconds=frame_interval_seconds,
+        )
+        cached_structured_data = cache.get(cache_key) if cache is not None else None
+
+        if cached_structured_data is not None:
+            structured_data = cached_structured_data
+        elif evidence.file_format == "IMAGE":
             messages = build_victim_image_messages(
                 image_bytes=evidence.file_bytes,
                 file_name=evidence.file_name,
                 file_format=evidence.file_format,
             )
+            structured_data = json.loads(llm_client.generate(messages))
+            if cache is not None:
+                cache.set(cache_key, structured_data)
         else:
             input_path = _materialize_input_file(evidence, temp_dir=temp_dir)
             frames_dir = temp_dir / "frames"
@@ -284,6 +298,9 @@ def _process_victim_evidence(
                 input_path,
                 default_interval_seconds=frame_interval_seconds,
             )
+            messages = None
+            if cache_key is None:
+                raise ValueError("cache_key must be available for VICTIM VIDEO.")
             frames = extract_frames_from_video(
                 input_path,
                 output_dir=frames_dir,
@@ -293,8 +310,9 @@ def _process_victim_evidence(
                 frames=frames,
                 file_name=evidence.file_name,
             )
-
-        structured_data = json.loads(llm_client.generate(messages))
+            structured_data = json.loads(llm_client.generate(messages))
+            if cache is not None:
+                cache.set(cache_key, structured_data)
     except Exception as exc:
         return EvidenceProcessingResult(
             evidence_id=evidence.evidence_id,
@@ -463,6 +481,25 @@ def _resolve_victim_video_frame_interval_seconds(
     if duration_seconds <= 20:
         return 1
     return default_interval_seconds
+
+def _compute_victim_cache_key(
+    evidence: TimelinePrototypeEvidenceInput,
+    *,
+    default_frame_interval_seconds: int,
+) -> str:
+    if evidence.file_bytes is None or evidence.file_format not in {"IMAGE", "VIDEO"}:
+        raise ValueError("VICTIM cache key requires IMAGE/VIDEO evidence with file_bytes.")
+
+    file_hash = hashlib.sha256(evidence.file_bytes).hexdigest()
+    payload = {
+        "type": evidence.type,
+        "file_format": evidence.file_format,
+        "file_hash": file_hash,
+        "frame_interval_seconds": default_frame_interval_seconds,
+        "prompt_version": "victim_prompt_v0",
+    }
+    serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return f"victim::{hashlib.sha256(serialized.encode('utf-8')).hexdigest()}"
 
 def _run_ocr(image_path: str, *, ocr_runner=None):
     if ocr_runner is not None:

--- a/tests/structuring/cache/test_hash.py
+++ b/tests/structuring/cache/test_hash.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from ansimon_ai.structuring.cache.hash import compute_input_hash
+from ansimon_ai.structuring.types import StructuringInput, StructuringSegment
+
+
+def test_compute_input_hash_accepts_datetime_timestamps() -> None:
+    struct_input = StructuringInput(
+        modality="text",
+        source_type="document",
+        language="ko",
+        full_text="2026-03-19 repeated threatening messages were documented.",
+        segments=[
+            StructuringSegment(
+                text="2026-03-19 repeated threatening messages were documented.",
+                start=0.0,
+                end=1.0,
+                timestamp=datetime(2026, 3, 19, 8, 45),
+            )
+        ],
+    )
+
+    result = compute_input_hash(
+        struct_input,
+        schema_version="v1.5",
+        prompt_version="v1.2",
+    )
+
+    assert isinstance(result, str)
+    assert result

--- a/tests/timeline/test_prototype.py
+++ b/tests/timeline/test_prototype.py
@@ -973,3 +973,367 @@ class VictimVideoLLMClient:
             },
             ensure_ascii=False,
         )
+
+class CountingLLMClient:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def generate(self, messages: list[dict]) -> str:
+        self.call_count += 1
+        return json.dumps(
+            {
+                "evidence_metadata": {
+                    "value": {
+                        "evidence_type": "text",
+                        "source": "unknown",
+                        "sources": ["unknown"],
+                        "created_at": "unknown",
+                    },
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "parties": {
+                    "value": {
+                        "actor": "unknown",
+                        "target": "unknown",
+                        "relationship": "unknown",
+                    },
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "period": {
+                    "value": "unknown",
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "frequency": {
+                    "value": "unknown",
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "channel": {
+                    "value": ["unknown"],
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "locations": {
+                    "value": ["unknown"],
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "action_types": {
+                    "value": [],
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "refusal_signal": {
+                    "value": "unknown",
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "threat_indicators": {
+                    "value": [],
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "impact_on_victim": {
+                    "value": [],
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "report_or_record": {
+                    "value": "unknown",
+                    "confidence": "low",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+                "timeline_summary": {
+                    "value": {
+                        "title": "cache test title",
+                        "description": "cache test description",
+                    },
+                    "confidence": "medium",
+                    "evidence_span": None,
+                    "evidence_anchor": None,
+                },
+            },
+            ensure_ascii=False,
+        )
+
+class InMemoryCache:
+    def __init__(self) -> None:
+        self._store: dict[str, dict] = {}
+
+    def get(self, key: str):
+        return self._store.get(key)
+
+    def set(self, key: str, value: dict) -> None:
+        self._store[key] = value
+
+def test_build_timeline_prototype_reuses_cached_results_for_existing_evidence(monkeypatch):
+    monkeypatch.setattr(
+        "ansimon_ai.structuring.run.compute_input_hash",
+        lambda input, schema_version, prompt_version: input.full_text,
+    )
+
+    llm_client = CountingLLMClient()
+    cache = InMemoryCache()
+
+    evidence_a = TimelinePrototypeEvidenceInput(
+        evidence_id=uuid4(),
+        type="REPORT_RECORD",
+        file_format="TXT",
+        extracted_text="2026-03-19 repeated threatening messages were documented.",
+    )
+    evidence_b = TimelinePrototypeEvidenceInput(
+        evidence_id=uuid4(),
+        type="REPORT_RECORD",
+        file_format="TXT",
+        extracted_text="2026-03-20 the actor appeared near the victim's workplace.",
+    )
+
+    first_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a],
+    )
+    first_result = build_timeline_prototype(
+        first_payload,
+        llm_client=llm_client,
+        cache=cache,
+    )
+
+    second_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a, evidence_b],
+    )
+    second_result = build_timeline_prototype(
+        second_payload,
+        llm_client=llm_client,
+        cache=cache,
+    )
+
+    assert len(first_result.evidence_results) == 1
+    assert len(second_result.evidence_results) == 2
+    assert llm_client.call_count == 2
+    assert second_result.evidence_results[0].title == "cache test title"
+    assert second_result.evidence_results[1].title == "cache test title"
+
+@pytest.mark.parametrize(
+    ("evidence_type", "file_format", "builder_key"),
+    [
+        ("REPORT_RECORD", "TXT", "report_record"),
+        ("INCIDENT_LOG", None, "incident_log_form"),
+        ("MESSAGE", "IMAGE", "message_image"),
+        ("VOICE", "AUDIO", "voice_audio"),
+    ],
+)
+def test_build_timeline_prototype_reuses_cached_results_by_type(
+    monkeypatch,
+    evidence_type: str,
+    file_format: str | None,
+    builder_key: str,
+):
+    monkeypatch.setattr(
+        "ansimon_ai.structuring.run.compute_input_hash",
+        lambda input, schema_version, prompt_version: input.full_text,
+    )
+
+    llm_client = CountingLLMClient()
+    cache = InMemoryCache()
+
+    def fake_ocr_runner(_image_path: str) -> OCRResult:
+        full_text = f"2026-03-17 18:30 repeated threatening message {_image_path}"
+        return OCRResult(
+            full_text=full_text,
+            segments=[
+                OCRSegment(
+                    text=full_text,
+                )
+            ],
+            language="ko",
+            engine="fake-ocr",
+        )
+
+    builders = {
+        "report_record": lambda text: TimelinePrototypeEvidenceInput(
+            evidence_id=uuid4(),
+            type="REPORT_RECORD",
+            file_format="TXT",
+            extracted_text=text,
+        ),
+        "incident_log_form": lambda text: TimelinePrototypeEvidenceInput(
+            evidence_id=uuid4(),
+            type="INCIDENT_LOG",
+            incident_log_form=IncidentLogFormInput(
+                title=text,
+                date="2026-03-19",
+                time="21:10",
+                place="home",
+                situation=text,
+            ),
+        ),
+        "message_image": lambda text: TimelinePrototypeEvidenceInput(
+            evidence_id=uuid4(),
+            type="MESSAGE",
+            file_format="IMAGE",
+            file_name="message.png",
+            file_bytes=b"fake-image",
+        ),
+        "voice_audio": lambda text: TimelinePrototypeEvidenceInput(
+            evidence_id=uuid4(),
+            type="VOICE",
+            file_format="AUDIO",
+            file_name="voice.m4a",
+            file_bytes=b"fake-audio",
+        ),
+    }
+
+    evidence_a = builders[builder_key]("first evidence")
+    evidence_b = builders[builder_key]("second evidence")
+
+    first_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a],
+    )
+    build_kwargs = {
+        "llm_client": llm_client,
+        "cache": cache,
+    }
+    if builder_key == "message_image":
+        build_kwargs["ocr_runner"] = fake_ocr_runner
+    if builder_key == "voice_audio":
+        build_kwargs["stt_engine"] = MockSTT()
+
+    build_timeline_prototype(first_payload, **build_kwargs)
+    first_request_count = llm_client.call_count
+
+    second_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a, evidence_b],
+    )
+    build_timeline_prototype(second_payload, **build_kwargs)
+    added_requests_on_second_run = llm_client.call_count - first_request_count
+
+    assert first_request_count == 1
+    assert added_requests_on_second_run == 1
+
+def test_build_timeline_prototype_reuses_cached_results_for_victim_image():
+    llm_client = CountingLLMClient()
+    cache = InMemoryCache()
+
+    evidence_a = TimelinePrototypeEvidenceInput(
+        evidence_id=uuid4(),
+        type="VICTIM",
+        file_format="IMAGE",
+        file_name="victim-a.jpg",
+        file_bytes=b"fake-image-a",
+    )
+    evidence_b = TimelinePrototypeEvidenceInput(
+        evidence_id=uuid4(),
+        type="VICTIM",
+        file_format="IMAGE",
+        file_name="victim-b.jpg",
+        file_bytes=b"fake-image-b",
+    )
+
+    first_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a],
+    )
+    build_timeline_prototype(
+        first_payload,
+        llm_client=llm_client,
+        cache=cache,
+    )
+    first_request_count = llm_client.call_count
+
+    second_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a, evidence_b],
+    )
+    build_timeline_prototype(
+        second_payload,
+        llm_client=llm_client,
+        cache=cache,
+    )
+    added_requests_on_second_run = llm_client.call_count - first_request_count
+
+    assert first_request_count == 1
+    assert added_requests_on_second_run == 1
+
+def test_build_timeline_prototype_reuses_cached_results_for_victim_video(monkeypatch):
+    llm_client = CountingLLMClient()
+    cache = InMemoryCache()
+
+    frame_one = _write_test_file(f"{uuid4()}-cache-frame1.jpg", b"frame-1")
+    frame_two = _write_test_file(f"{uuid4()}-cache-frame2.jpg", b"frame-2")
+
+    from ansimon_ai.video import ExtractedVideoFrame
+
+    def fake_get_video_duration_seconds(_input_path: str) -> float:
+        return 45.0
+
+    def fake_extract_frames_from_video(*args, **kwargs):
+        return [
+            ExtractedVideoFrame(path=frame_one, frame_index=0, frame_timestamp_seconds=0),
+            ExtractedVideoFrame(path=frame_two, frame_index=1, frame_timestamp_seconds=10),
+        ]
+
+    monkeypatch.setattr(
+        "ansimon_ai.timeline.prototype.get_video_duration_seconds",
+        fake_get_video_duration_seconds,
+    )
+    monkeypatch.setattr(
+        "ansimon_ai.timeline.prototype.extract_frames_from_video",
+        fake_extract_frames_from_video,
+    )
+
+    evidence_a = TimelinePrototypeEvidenceInput(
+        evidence_id=uuid4(),
+        type="VICTIM",
+        file_format="VIDEO",
+        file_name="victim-a.mp4",
+        file_bytes=b"fake-video-a",
+    )
+    evidence_b = TimelinePrototypeEvidenceInput(
+        evidence_id=uuid4(),
+        type="VICTIM",
+        file_format="VIDEO",
+        file_name="victim-b.mp4",
+        file_bytes=b"fake-video-b",
+    )
+
+    first_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a],
+    )
+    build_timeline_prototype(
+        first_payload,
+        llm_client=llm_client,
+        cache=cache,
+    )
+    first_request_count = llm_client.call_count
+
+    second_payload = TimelinePrototypeAiInput(
+        complaint_id=uuid4(),
+        evidences=[evidence_a, evidence_b],
+    )
+    build_timeline_prototype(
+        second_payload,
+        llm_client=llm_client,
+        cache=cache,
+    )
+    added_requests_on_second_run = llm_client.call_count - first_request_count
+
+    assert first_request_count == 1
+    assert added_requests_on_second_run == 1


### PR DESCRIPTION
## 작업 내용
> step1과 step2를 오갈 때 기존에 분석한 증거는 재사용하고, 새로 추가된 증거만 분석되도록 캐시 재사용 흐름을 정리하고 보강했습니다.

현재 타임라인 프로토타입은 step1에서 선택한 증거 전체를 기준으로 다시 실행되는 구조이지만, 실제로는 같은 증거가 다시 들어왔을 때 기존 결과를 재사용하고 새 증거만 추가 분석되는 흐름이 필요합니다.

이번 PR에서는 기존 캐시 기반 재사용 동작을 검증하고, 특히 `VICTIM` 증거도 같은 방식으로 재사용되도록 보강했습니다.

**주요 작업**
- structuring cache hash의 `datetime` 직렬화 오류 수정
- `VICTIM IMAGE/VIDEO` 경로에 cache 재사용 적용
- 증거 타입별 증분 재사용 테스트 추가

## 이슈 번호
#79 

## 스크린샷 (선택)
<img width="595" height="367" alt="image" src="https://github.com/user-attachments/assets/b9ae2f8e-c717-4e76-ba62-658ecf03ca8f" />

> 증거 하나(폭행.jpg)만 넣고 AI 분석 1차 실행

<img width="608" height="481" alt="image" src="https://github.com/user-attachments/assets/0ef2dd6d-50b8-4bf7-b8a7-6943b7da2a5a" />

> 기존 증거(폭행.jpg)는 유지한 채 새로운 증거(눈멍.jpg) 추가 후 AI 분석 2차 실행