### PR TITLE
[FIX][#82]: 고소장/진술서 생성용 mock LLM 응답 지원

### DIFF
--- a/src/ansimon_ai/llm/mock.py
+++ b/src/ansimon_ai/llm/mock.py
@@ -4,6 +4,14 @@ from .base import LLMClient
 
 class MockLLMClient(LLMClient):
     def generate(self, messages: list[dict]) -> str:
+        user_content = _extract_user_text(messages)
+
+        if "Write the complaint document sections strictly from the provided input." in user_content:
+            return json.dumps(_build_complaint_document_mock(), ensure_ascii=False)
+
+        if "Write the damage facts statement strictly from the provided input." in user_content:
+            return json.dumps(_build_damage_facts_statement_mock(), ensure_ascii=False)
+
         doc = {
             "evidence_metadata": {
                 "value": {
@@ -98,3 +106,54 @@ class MockLLMClient(LLMClient):
         }
 
         return json.dumps(doc, ensure_ascii=False)
+
+
+def _extract_user_text(messages: list[dict]) -> str:
+    texts: list[str] = []
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+
+        content = message.get("content")
+        if isinstance(content, str):
+            texts.append(content)
+            continue
+
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and item.get("type") == "text":
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        texts.append(text)
+
+    return "\n".join(texts)
+
+
+def _build_complaint_document_mock() -> dict:
+    return {
+        "section_4_crime_facts": (
+            "2026년 2월 16일 새벽 5시 30분경, 피고소인은 고소인에게 반복적인 협박성 문자메시지를 발송하였습니다. "
+            "같은 날 오전 8시 30분경에는 고소인의 출근길 이동 경로를 따라오는 정황이 확인되었고, "
+            "2026년 2월 18일 오후 5시경에는 퇴근길 편의점 앞에서 직접 접근을 시도하였습니다."
+        ),
+        "section_5_complaint_reason": (
+            "고소인은 명시적으로 연락을 거부하였음에도 피고소인의 반복적인 연락과 접근이 계속되어 "
+            "불안과 공포를 느끼고 있으며, 일상생활과 수면에 지장을 겪고 있어 본 고소를 제기합니다."
+        ),
+        "section_6_evidence_list_text": [
+            "새벽 협박 문자 스크린샷 (2026.02.16)",
+            "출근길 블랙박스 영상 (2026.02.16)",
+            "퇴근길 접근 시도 관련 진술 (2026.02.18)",
+        ],
+    }
+
+
+def _build_damage_facts_statement_mock() -> dict:
+    return {
+        "damage_facts_statement": (
+            "2026년 2월 16일 새벽부터 피고소인으로부터 협박성 문자메시지를 반복적으로 받았고, "
+            "같은 날 출근길에는 피고소인으로 추정되는 차량이 제 이동 경로를 따라오는 장면이 확인되었습니다. "
+            "이후 2026년 2월 18일 퇴근길 편의점 앞에서 직접 접근 시도까지 있어 큰 불안과 공포를 느꼈으며, "
+            "현재까지도 일상생활과 수면에 지장이 발생하고 있습니다."
+        )
+    }

--- a/tests/writing/test_generate.py
+++ b/tests/writing/test_generate.py
@@ -1,16 +1,17 @@
 import json
 from uuid import uuid4
 
+from ansimon_ai.llm.mock import MockLLMClient
+from ansimon_ai.writing.generate import (
+    generate_complaint_document,
+    generate_damage_facts_statement,
+)
 from schemas.complaint_writing import (
     ComplaintWritingAiInput,
     ComplaintWritingDateItem,
     ComplaintWritingEvent,
     ComplaintWritingStructuredContext,
     ComplaintWritingTimelineItem,
-)
-from ansimon_ai.writing.generate import (
-    generate_complaint_document,
-    generate_damage_facts_statement,
 )
 
 class DummyLLMClient:
@@ -48,7 +49,7 @@ def _make_ai_input() -> ComplaintWritingAiInput:
             ComplaintWritingStructuredContext(
                 evidence_id=uuid4(),
                 channel=["offline"],
-                locations=["주차장"],
+                locations=["주거지"],
                 action_types=["접근", "폭행"],
                 impact_on_victim=["불안", "공포"],
             )
@@ -84,3 +85,15 @@ def test_generate_damage_facts_statement_returns_valid_output() -> None:
 
     assert result.damage_facts_statement == "피해 사실 진술 본문"
     assert llm_client.last_messages is not None
+
+def test_generate_document_outputs_with_mock_llm_client() -> None:
+    ai_input = _make_ai_input()
+    llm_client = MockLLMClient()
+
+    complaint_result = generate_complaint_document(ai_input, llm_client=llm_client)
+    statement_result = generate_damage_facts_statement(ai_input, llm_client=llm_client)
+
+    assert complaint_result.section_4_crime_facts
+    assert complaint_result.section_5_complaint_reason
+    assert complaint_result.section_6_evidence_list_text
+    assert statement_result.damage_facts_statement


### PR DESCRIPTION
## 작업 내용
> 문서 작성 단계에서 `MockLLMClient`를 사용할 때 output shape mismatch로 발생하던 validation error를 수정했습니다.

기존 `MockLLMClient`는 structuring 결과용 JSON만 반환하도록 되어 있어, 고소장/진술서 생성 함수에 그대로 사용할 경우 문서 작성 output 스키마와 맞지 않아 validation error가 발생했습니다.
이번 PR에서는 `MockLLMClient`가 문서 작성 메시지도 인식할 수 있도록 확장해서, OpenAI 없이도 고소장/진술서 생성 흐름을 mock 기반으로 확인할 수 있게 했습니다.

**주요 작업**
- `MockLLMClient`에 문서 작성용 응답 분기 추가
- 고소장 생성요 mock JSON 반환 지원
- 진술서 생성용 mock JSON 반환 지원
- 문서 작성 함수에 `MockLLMClient`를 넣어도 validation error 없이 동작하는 테스트 추가

**사용 방식**
mock으로 문서 작성 흐름을 확인할 때는 아래처럼 사용하면 됩니다.
- 고소장
  - `generate_complaint_document(ai_input, llm_client=MockLLMClient())`
- 진술서
  - `generate_damage_facts_statement(ai_input, llm_client=MockLLMClient))`

## 이슈 번호
#82 

## 스크린샷 (선택)
N/A