### PR TITLE
[MOD][#88]: PDF/DOCX 이미지 OCR에 Clova 선택 및 표 처리 적용

### DIFF
--- a/src/ansimon_ai/ocr/clova_ocr.py
+++ b/src/ansimon_ai/ocr/clova_ocr.py
@@ -1,15 +1,20 @@
 import base64
 import os
 import time
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Optional
 from uuid import uuid4
 
+from PIL import Image as PILImage
+
 from .layout import assign_speaker_sides
 from .types import OCRResult, OCRSegment, OCRVertex
 
+ImageInput = str | Path | PILImage.Image
+
 def clova_ocr_image_to_result(
-    image_path: str,
+    image_input: ImageInput,
     *,
     invoke_url: Optional[str] = None,
     secret: Optional[str] = None,
@@ -32,9 +37,7 @@ def clova_ocr_image_to_result(
         raise ValueError("CLOVA_OCR_SECRET is required.")
 
     request_url = _resolve_general_url(resolved_invoke_url)
-    file_path = Path(image_path)
-    image_bytes = file_path.read_bytes()
-    image_format = _infer_image_format(file_path)
+    image_bytes, image_format, image_name = _read_image_input(image_input)
 
     payload = {
         "version": "V2",
@@ -44,7 +47,7 @@ def clova_ocr_image_to_result(
         "images": [
             {
                 "format": image_format,
-                "name": file_path.name,
+                "name": image_name,
                 "data": base64.b64encode(image_bytes).decode("ascii"),
             }
         ],
@@ -89,6 +92,15 @@ def _infer_image_format(path: Path) -> str:
     if suffix not in mapping:
         raise ValueError(f"Unsupported image format for CLOVA OCR: {suffix}")
     return mapping[suffix]
+
+def _read_image_input(image_input: ImageInput) -> tuple[bytes, str, str]:
+    if isinstance(image_input, PILImage.Image):
+        buffer = BytesIO()
+        image_input.save(buffer, format="PNG")
+        return buffer.getvalue(), "png", "image.png"
+
+    file_path = Path(image_input)
+    return file_path.read_bytes(), _infer_image_format(file_path), file_path.name
 
 def _parse_clova_ocr_response(data: dict[str, Any]) -> OCRResult:
     images = data.get("images")

--- a/src/ansimon_ai/ocr/clova_ocr.py
+++ b/src/ansimon_ai/ocr/clova_ocr.py
@@ -9,9 +9,10 @@ from uuid import uuid4
 from PIL import Image as PILImage
 
 from .layout import assign_speaker_sides
-from .types import OCRResult, OCRSegment, OCRVertex
+from .types import OCRResult, OCRSegment, OCRTable, OCRTableCell, OCRTableLine, OCRTableWord, OCRVertex
 
 ImageInput = str | Path | PILImage.Image
+_TABLE_DETECTION_DISABLED_CODE = "0028"
 
 def clova_ocr_image_to_result(
     image_input: ImageInput,
@@ -44,6 +45,7 @@ def clova_ocr_image_to_result(
         "requestId": str(uuid4()),
         "timestamp": int(time.time() * 1000),
         "lang": lang,
+        "enableTableDetection": True,
         "images": [
             {
                 "format": image_format,
@@ -58,18 +60,44 @@ def clova_ocr_image_to_result(
     except ModuleNotFoundError as exc:
         raise ModuleNotFoundError("requests is required for CLOVA OCR integration.") from exc
 
-    response = requests.post(
+    headers = {
+        "Content-Type": "application/json",
+        "X-OCR-SECRET": resolved_secret,
+    }
+    response = _post_clova_request(
+        requests,
         request_url,
-        headers={
-            "Content-Type": "application/json",
-            "X-OCR-SECRET": resolved_secret,
-        },
+        headers=headers,
+        payload=payload,
+    )
+
+    return _parse_clova_ocr_response(response.json())
+
+
+def _post_clova_request(requests_module, request_url: str, *, headers: dict[str, str], payload: dict[str, Any]):
+    response = requests_module.post(
+        request_url,
+        headers=headers,
         json=payload,
         timeout=30,
     )
-    response.raise_for_status()
 
-    return _parse_clova_ocr_response(response.json())
+    try:
+        response.raise_for_status()
+        return response
+    except requests_module.HTTPError:
+        if payload.get("enableTableDetection") and _is_table_detection_disabled_response(response):
+            fallback_payload = dict(payload)
+            fallback_payload["enableTableDetection"] = False
+            fallback_response = requests_module.post(
+                request_url,
+                headers=headers,
+                json=fallback_payload,
+                timeout=30,
+            )
+            fallback_response.raise_for_status()
+            return fallback_response
+        raise
 
 def _resolve_general_url(invoke_url: str) -> str:
     normalized = invoke_url.rstrip("/")
@@ -111,6 +139,7 @@ def _parse_clova_ocr_response(data: dict[str, Any]) -> OCRResult:
     fields = first_image.get("fields")
     if not isinstance(fields, list):
         raise ValueError("CLOVA OCR response does not contain fields.")
+    tables = _parse_tables(first_image.get("tables"))
 
     segments: list[OCRSegment] = []
     tokens: list[str] = []
@@ -162,8 +191,166 @@ def _parse_clova_ocr_response(data: dict[str, Any]) -> OCRResult:
         segments=segments,
         language=data.get("lang") or "ko",
         engine="clova:v2",
+        tables=tables,
     )
     return assign_speaker_sides(result)
+
+
+def _is_table_detection_disabled_response(response) -> bool:
+    try:
+        data = response.json()
+    except ValueError:
+        data = None
+
+    if not isinstance(data, dict):
+        return _TABLE_DETECTION_DISABLED_CODE in (getattr(response, "text", "") or "")
+
+    code_candidates: list[str] = []
+    for key in ("code", "statusCode"):
+        value = data.get(key)
+        if value is not None:
+            code_candidates.append(str(value))
+
+    for nested_key in ("status", "error"):
+        nested = data.get(nested_key)
+        if isinstance(nested, dict):
+            value = nested.get("code")
+            if value is not None:
+                code_candidates.append(str(value))
+
+    if _TABLE_DETECTION_DISABLED_CODE in code_candidates:
+        return True
+
+    messages = [str(data.get("message") or "")]
+    for nested_key in ("status", "error"):
+        nested = data.get(nested_key)
+        if isinstance(nested, dict):
+            messages.append(str(nested.get("message") or ""))
+
+    return any("Table detection disabled" in message for message in messages)
+
+
+def _parse_tables(raw_tables: Any) -> list[OCRTable]:
+    if not isinstance(raw_tables, list):
+        return []
+
+    tables: list[OCRTable] = []
+    for raw_table in raw_tables:
+        if not isinstance(raw_table, dict):
+            continue
+
+        cells: list[OCRTableCell] = []
+        raw_cells = raw_table.get("cells")
+        if isinstance(raw_cells, list):
+            for raw_cell in raw_cells:
+                cell = _parse_table_cell(raw_cell)
+                if cell is not None:
+                    cells.append(cell)
+
+        tables.append(
+            OCRTable(
+                text=str(raw_table.get("inferText") or "").strip(),
+                confidence=_to_float(raw_table.get("inferConfidence")),
+                vertices=_parse_vertices(raw_table),
+                cells=cells,
+            )
+        )
+
+    return tables
+
+
+def _parse_table_cell(raw_cell: Any) -> OCRTableCell | None:
+    if not isinstance(raw_cell, dict):
+        return None
+
+    lines = _parse_table_lines(raw_cell.get("cellTextLines"))
+    text = _extract_table_cell_text(raw_cell, lines)
+    if not text:
+        return None
+
+    return OCRTableCell(
+        text=text,
+        row_index=_to_int(raw_cell.get("rowIndex"), default=0),
+        column_index=_to_int(raw_cell.get("columnIndex"), default=0),
+        row_span=max(_to_int(raw_cell.get("rowSpan"), default=1), 1),
+        column_span=max(_to_int(raw_cell.get("columnSpan"), default=1), 1),
+        confidence=_to_float(raw_cell.get("inferConfidence")),
+        vertices=_parse_vertices(raw_cell),
+        lines=lines,
+    )
+
+
+def _parse_table_lines(raw_lines: Any) -> list[OCRTableLine]:
+    if not isinstance(raw_lines, list):
+        return []
+
+    lines: list[OCRTableLine] = []
+    for raw_line in raw_lines:
+        if not isinstance(raw_line, dict):
+            continue
+
+        words = _parse_table_words(raw_line.get("cellWords"))
+        text = " ".join(word.text for word in words).strip()
+        if not text:
+            continue
+
+        lines.append(
+            OCRTableLine(
+                text=text,
+                confidence=_to_float(raw_line.get("inferConfidence")),
+                vertices=_parse_vertices(raw_line),
+                words=words,
+            )
+        )
+
+    return lines
+
+
+def _parse_table_words(raw_words: Any) -> list[OCRTableWord]:
+    if not isinstance(raw_words, list):
+        return []
+
+    words: list[OCRTableWord] = []
+    for raw_word in raw_words:
+        if not isinstance(raw_word, dict):
+            continue
+
+        text = str(raw_word.get("inferText") or "").strip()
+        if not text:
+            continue
+
+        words.append(
+            OCRTableWord(
+                text=text,
+                confidence=_to_float(raw_word.get("inferConfidence")),
+                vertices=_parse_vertices(raw_word),
+            )
+        )
+
+    return words
+
+
+def _extract_table_cell_text(raw_cell: dict[str, Any], lines: list[OCRTableLine]) -> str:
+    line_text = "\n".join(line.text for line in lines if line.text).strip()
+    if line_text:
+        return line_text
+    return str(raw_cell.get("inferText") or "").strip()
+
+
+def _to_int(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 def _parse_vertices(field: dict[str, Any]) -> list[OCRVertex]:
     bounding_poly = field.get("boundingPoly")

--- a/src/ansimon_ai/ocr/from_ocr.py
+++ b/src/ansimon_ai/ocr/from_ocr.py
@@ -1,7 +1,10 @@
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
+
+from PIL import Image as PILImage
 
 from .types import OCRResult
 from .types import OCRSegment
@@ -9,6 +12,8 @@ from .clova_ocr import clova_ocr_image_to_result
 
 from ansimon_ai.structuring.types import StructuringInput, StructuringSegment
 from ansimon_ai.structuring.timestamp_utils import extract_timestamp
+
+ImageInput = str | Path | PILImage.Image
 
 _UI_EDGE_CHARS = "<>=_+-@…·|~ "
 _UI_ONLY_VALUES = {"글", "메시지 입력", "message"}
@@ -214,15 +219,18 @@ def _run_ocr_variant(pytesseract, output_cls, image, *, lang: str, config: str, 
         engine=engine_name,
     )
 
-def tesseract_ocr_image_to_result(image_path: str) -> OCRResult:
+def tesseract_ocr_image_to_result(
+    image_input: ImageInput,
+    *,
+    lang: str = "kor+eng",
+) -> OCRResult:
     import pytesseract
-    from PIL import Image
 
     tesseract_cmd = r"C:\Program Files\Tesseract-OCR\tesseract.exe"
     if os.name == "nt" and os.path.exists(tesseract_cmd):
         pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
 
-    image = Image.open(image_path)
+    image = _load_image_input(image_input)
     variants = _prepare_ocr_variants(image)
 
     best_result: OCRResult | None = None
@@ -233,7 +241,7 @@ def tesseract_ocr_image_to_result(image_path: str) -> OCRResult:
             pytesseract,
             pytesseract.Output,
             variant_image,
-            lang="kor+eng",
+            lang=lang,
             config=config,
             engine_name=f"tesseract:{variant_name}",
         )
@@ -245,13 +253,41 @@ def tesseract_ocr_image_to_result(image_path: str) -> OCRResult:
     assert best_result is not None
     return best_result
 
-def ocr_image_to_result(image_path: str, *, engine: Optional[str] = None) -> OCRResult:
+def ocr_image_to_result(
+    image_input: ImageInput,
+    *,
+    engine: Optional[str] = None,
+    lang: Optional[str] = None,
+) -> OCRResult:
     resolved_engine = _resolve_ocr_engine(engine)
     if resolved_engine == "clova":
-        return clova_ocr_image_to_result(image_path)
+        if lang is None:
+            return clova_ocr_image_to_result(image_input)
+        return clova_ocr_image_to_result(image_input, lang=_normalize_clova_lang(lang))
     if resolved_engine == "tesseract":
-        return tesseract_ocr_image_to_result(image_path)
+        if lang is None:
+            return tesseract_ocr_image_to_result(image_input)
+        return tesseract_ocr_image_to_result(image_input, lang=lang)
     raise ValueError(f"Unsupported OCR engine: {resolved_engine}")
+
+def _load_image_input(image_input: ImageInput) -> PILImage.Image:
+    if isinstance(image_input, PILImage.Image):
+        return image_input.copy()
+
+    with PILImage.open(image_input) as image:
+        return image.copy()
+
+def _normalize_clova_lang(lang: str) -> str:
+    token = lang.split("+", 1)[0].strip().lower()
+    mapping = {
+        "ko": "ko",
+        "kor": "ko",
+        "en": "en",
+        "eng": "en",
+        "ja": "ja",
+        "jpn": "ja",
+    }
+    return mapping.get(token, token)
 
 def _resolve_ocr_engine(engine: Optional[str]) -> str:
     try:

--- a/src/ansimon_ai/ocr/from_ocr.py
+++ b/src/ansimon_ai/ocr/from_ocr.py
@@ -9,6 +9,7 @@ from PIL import Image as PILImage
 from .types import OCRResult
 from .types import OCRSegment
 from .clova_ocr import clova_ocr_image_to_result
+from .table_formatting import format_ocr_result_text, is_tabular_table
 
 from ansimon_ai.structuring.types import StructuringInput, StructuringSegment
 from ansimon_ai.structuring.timestamp_utils import extract_timestamp
@@ -111,7 +112,7 @@ def build_structuring_input_from_ocr(
     metadata_fallback_timestamp: Optional[datetime] = None,
 ) -> StructuringInput:
     segments = preprocess_ocr_segments(ocr.segments)
-    full_text = "\n".join(seg.get("text", "") for seg in segments).strip()
+    full_text = _build_ocr_full_text(ocr, segments)
     return StructuringInput(
         modality="text",
         source_type="ocr",
@@ -130,6 +131,15 @@ def build_structuring_input_from_ocr(
             for seg in segments
         ],
     )
+
+def _build_ocr_full_text(ocr: OCRResult, segments: list[dict]) -> str:
+    if any(is_tabular_table(table) for table in ocr.tables):
+        formatted_text = format_ocr_result_text(ocr).strip()
+        if formatted_text:
+            return formatted_text
+
+    processed_text = "\n".join(seg.get("text", "") for seg in segments).strip()
+    return processed_text or ocr.full_text
 
 def _prepare_ocr_variants(image):
     from PIL import ImageFilter, ImageOps

--- a/src/ansimon_ai/ocr/table_formatting.py
+++ b/src/ansimon_ai/ocr/table_formatting.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from ansimon_ai.ocr.types import OCRResult, OCRSegment, OCRTable, OCRVertex
+
+
+def render_table_text(table: OCRTable) -> str:
+    if not table.cells:
+        return table.text.strip()
+
+    max_row = max(cell.row_index for cell in table.cells)
+    max_col = max(cell.column_index for cell in table.cells)
+    rows = [["" for _ in range(max_col + 1)] for _ in range(max_row + 1)]
+
+    for cell in sorted(table.cells, key=lambda item: (item.row_index, item.column_index)):
+        value = cell.text.strip()
+        if not value:
+            continue
+
+        row_index = max(cell.row_index, 0)
+        column_index = max(cell.column_index, 0)
+        current = rows[row_index][column_index].strip()
+        if current and current != value:
+            rows[row_index][column_index] = f"{current} / {value}"
+        else:
+            rows[row_index][column_index] = value
+
+    rendered_rows: list[str] = []
+    for row in rows:
+        normalized = [cell.strip() for cell in row]
+        if any(normalized):
+            rendered_rows.append(" | ".join(normalized))
+
+    return "\n".join(rendered_rows).strip()
+
+
+def is_tabular_table(table: OCRTable) -> bool:
+    if len(table.cells) < 2:
+        return False
+    distinct_columns = {cell.column_index for cell in table.cells}
+    return len(distinct_columns) >= 2
+
+
+def format_ocr_result_text(result: OCRResult) -> str:
+    segment_lines = [segment.text.strip() for segment in result.segments if segment.text.strip()]
+    tabular_tables = [table for table in result.tables if is_tabular_table(table)]
+
+    if not tabular_tables:
+        return "\n".join(segment_lines).strip() or (result.full_text or "").strip()
+
+    if not segment_lines:
+        rendered = [render_table_text(table) for table in tabular_tables if render_table_text(table)]
+        return "\n\n".join(rendered).strip() or (result.full_text or "").strip()
+
+    table_ranges = _build_table_ranges(result, tabular_tables)
+    if not table_ranges:
+        base_text = "\n".join(segment_lines).strip() or (result.full_text or "").strip()
+        rendered = [render_table_text(table) for table in tabular_tables if render_table_text(table)]
+        if base_text and rendered:
+            return f"{base_text}\n\n" + "\n\n".join(rendered)
+        return base_text or "\n\n".join(rendered).strip()
+
+    rendered_lines: list[str] = []
+    consumed_indexes: set[int] = set()
+
+    for index, segment in enumerate(result.segments):
+        if index in consumed_indexes:
+            continue
+
+        matched = None
+        for table, covered_indexes in table_ranges:
+            if covered_indexes and covered_indexes[0] == index:
+                matched = (table, covered_indexes)
+                break
+
+        if matched is not None:
+            table, covered_indexes = matched
+            table_text = render_table_text(table)
+            if table_text:
+                rendered_lines.append(table_text)
+            consumed_indexes.update(covered_indexes)
+            continue
+
+        text = segment.text.strip()
+        if text:
+            rendered_lines.append(text)
+
+    return "\n".join(rendered_lines).strip() or "\n".join(segment_lines).strip() or (result.full_text or "").strip()
+
+
+def _build_table_ranges(result: OCRResult, tables: list[OCRTable]) -> list[tuple[OCRTable, list[int]]]:
+    ranges: list[tuple[OCRTable, list[int]]] = []
+    for table in tables:
+        covered_indexes = [
+            index
+            for index, segment in enumerate(result.segments)
+            if _segment_is_within_table(segment, table)
+        ]
+        if covered_indexes:
+            ranges.append((table, covered_indexes))
+    return sorted(ranges, key=lambda item: item[1][0])
+
+
+def _segment_is_within_table(segment: OCRSegment, table: OCRTable) -> bool:
+    table_bounds = _table_bounds(table)
+    if (
+        segment.min_x is None
+        or segment.max_x is None
+        or segment.min_y is None
+        or segment.max_y is None
+        or table_bounds is None
+    ):
+        return False
+
+    table_min_x, table_max_x, table_min_y, table_max_y = table_bounds
+    center_x = segment.center_x
+    center_y = segment.center_y
+    if center_x is not None and center_y is not None:
+        if table_min_x <= center_x <= table_max_x and table_min_y <= center_y <= table_max_y:
+            return True
+
+    overlap_width = min(segment.max_x, table_max_x) - max(segment.min_x, table_min_x)
+    overlap_height = min(segment.max_y, table_max_y) - max(segment.min_y, table_min_y)
+    if overlap_width <= 0 or overlap_height <= 0:
+        return False
+
+    segment_area = (segment.max_x - segment.min_x) * (segment.max_y - segment.min_y)
+    if segment_area <= 0:
+        return False
+
+    overlap_ratio = (overlap_width * overlap_height) / segment_area
+    return overlap_ratio >= 0.5
+
+
+def _table_bounds(table: OCRTable) -> tuple[float, float, float, float] | None:
+    vertices: list[OCRVertex] = []
+    if table.vertices:
+        vertices.extend(table.vertices)
+    else:
+        for cell in table.cells:
+            if cell.vertices:
+                vertices.extend(cell.vertices)
+
+    if not vertices:
+        return None
+
+    return (
+        min(vertex.x for vertex in vertices),
+        max(vertex.x for vertex in vertices),
+        min(vertex.y for vertex in vertices),
+        max(vertex.y for vertex in vertices),
+    )

--- a/src/ansimon_ai/ocr/types.py
+++ b/src/ansimon_ai/ocr/types.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel
 from typing import List, Optional
+
+from pydantic import BaseModel, Field
 
 class OCRVertex(BaseModel):
     x: float
@@ -51,8 +52,40 @@ class OCRSegment(BaseModel):
             return None
         return (self.min_y + self.max_y) / 2.0
 
+
+class OCRTableWord(BaseModel):
+    text: str
+    confidence: Optional[float] = None
+    vertices: Optional[List[OCRVertex]] = None
+
+
+class OCRTableLine(BaseModel):
+    text: str
+    confidence: Optional[float] = None
+    vertices: Optional[List[OCRVertex]] = None
+    words: List[OCRTableWord] = Field(default_factory=list)
+
+
+class OCRTableCell(BaseModel):
+    text: str
+    row_index: int
+    column_index: int
+    row_span: int = 1
+    column_span: int = 1
+    confidence: Optional[float] = None
+    vertices: Optional[List[OCRVertex]] = None
+    lines: List[OCRTableLine] = Field(default_factory=list)
+
+
+class OCRTable(BaseModel):
+    text: str = ""
+    confidence: Optional[float] = None
+    vertices: Optional[List[OCRVertex]] = None
+    cells: List[OCRTableCell] = Field(default_factory=list)
+
 class OCRResult(BaseModel):
     full_text: str
     segments: List[OCRSegment]
     language: Optional[str] = None
     engine: str
+    tables: List[OCRTable] = Field(default_factory=list)

--- a/src/ansimon_ai/pdf/extract_image_pdf.py
+++ b/src/ansimon_ai/pdf/extract_image_pdf.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from pdf2image import convert_from_path
 
 from ansimon_ai.ocr.from_ocr import ocr_image_to_result
+from ansimon_ai.ocr.table_formatting import format_ocr_result_text
 
 def extract_text_from_image_pdf(
     pdf_path: str,
@@ -12,7 +13,7 @@ def extract_text_from_image_pdf(
     texts = []
     for img in images:
         result = ocr_image_to_result(img, engine=engine, lang=lang)
-        texts.append(result.full_text)
+        texts.append(format_ocr_result_text(result))
     return texts
 
 def extract_text_from_image_pdf_page(
@@ -29,4 +30,4 @@ def extract_text_from_image_pdf_page(
     if not images:
         return ""
     result = ocr_image_to_result(images[0], engine=engine, lang=lang)
-    return result.full_text
+    return format_ocr_result_text(result)

--- a/src/ansimon_ai/pdf/extract_image_pdf.py
+++ b/src/ansimon_ai/pdf/extract_image_pdf.py
@@ -1,16 +1,26 @@
-from typing import List
+from typing import List, Optional
 from pdf2image import convert_from_path
-import pytesseract
 
-def extract_text_from_image_pdf(pdf_path: str, lang: str = "kor") -> List[str]:
+from ansimon_ai.ocr.from_ocr import ocr_image_to_result
+
+def extract_text_from_image_pdf(
+    pdf_path: str,
+    lang: str = "kor",
+    engine: Optional[str] = None,
+) -> List[str]:
     images = convert_from_path(pdf_path)
     texts = []
     for img in images:
-        text = pytesseract.image_to_string(img, lang=lang)
-        texts.append(text)
+        result = ocr_image_to_result(img, engine=engine, lang=lang)
+        texts.append(result.full_text)
     return texts
 
-def extract_text_from_image_pdf_page(pdf_path: str, page_index: int, lang: str = "kor") -> str:
+def extract_text_from_image_pdf_page(
+    pdf_path: str,
+    page_index: int,
+    lang: str = "kor",
+    engine: Optional[str] = None,
+) -> str:
     images = convert_from_path(
         pdf_path,
         first_page=page_index + 1,
@@ -18,4 +28,5 @@ def extract_text_from_image_pdf_page(pdf_path: str, page_index: int, lang: str =
     )
     if not images:
         return ""
-    return pytesseract.image_to_string(images[0], lang=lang)
+    result = ocr_image_to_result(images[0], engine=engine, lang=lang)
+    return result.full_text

--- a/src/ansimon_ai/pdf/extract_text_auto.py
+++ b/src/ansimon_ai/pdf/extract_text_auto.py
@@ -1,9 +1,13 @@
-from typing import List
+from typing import List, Optional
 from .detect_pdf_type import detect_pdf_page_types, detect_pdf_type
 from .extract_text_pdf import extract_text_from_pdf, extract_text_from_pdf_page
 from .extract_image_pdf import extract_text_from_image_pdf, extract_text_from_image_pdf_page
 
-def extract_text_auto(pdf_path: str, lang: str = "kor") -> List[str]:
+def extract_text_auto(
+    pdf_path: str,
+    lang: str = "kor",
+    engine: Optional[str] = None,
+) -> List[str]:
     pdf_type, _ = detect_pdf_type(pdf_path)
     if pdf_type == "text":
         page_types = detect_pdf_page_types(pdf_path)
@@ -15,17 +19,31 @@ def extract_text_auto(pdf_path: str, lang: str = "kor") -> List[str]:
             if page_type == "text":
                 texts.append(extract_text_from_pdf_page(pdf_path, page_index))
             else:
-                texts.append(extract_text_from_image_pdf_page(pdf_path, page_index, lang=lang))
+                texts.append(
+                    extract_text_from_image_pdf_page(
+                        pdf_path,
+                        page_index,
+                        lang=lang,
+                        engine=engine,
+                    )
+                )
         return texts
     else:
         page_types = detect_pdf_page_types(pdf_path)
         if all(page_type == "image" for page_type in page_types):
-            return extract_text_from_image_pdf(pdf_path, lang=lang)
+            return extract_text_from_image_pdf(pdf_path, lang=lang, engine=engine)
 
         texts = []
         for page_index, page_type in enumerate(page_types):
             if page_type == "text":
                 texts.append(extract_text_from_pdf_page(pdf_path, page_index))
             else:
-                texts.append(extract_text_from_image_pdf_page(pdf_path, page_index, lang=lang))
+                texts.append(
+                    extract_text_from_image_pdf_page(
+                        pdf_path,
+                        page_index,
+                        lang=lang,
+                        engine=engine,
+                    )
+                )
         return texts

--- a/src/ansimon_ai/pdf/extract_text_docx.py
+++ b/src/ansimon_ai/pdf/extract_text_docx.py
@@ -6,6 +6,7 @@ from zipfile import ZipFile
 from PIL import Image, UnidentifiedImageError
 
 from ansimon_ai.ocr.from_ocr import ocr_image_to_result
+from ansimon_ai.ocr.table_formatting import format_ocr_result_text
 
 def _normalize_line(text: str) -> str:
     text = text.replace("\r", " ").replace("\n", " ")
@@ -55,8 +56,9 @@ def _extract_text_from_docx_images(
             except (UnidentifiedImageError, OSError):
                 continue
 
-            if result.full_text.strip():
-                _append_normalized_lines(image_texts, result.full_text)
+            formatted_text = format_ocr_result_text(result)
+            if formatted_text.strip():
+                _append_normalized_lines(image_texts, formatted_text)
 
     return image_texts
 

--- a/src/ansimon_ai/pdf/extract_text_docx.py
+++ b/src/ansimon_ai/pdf/extract_text_docx.py
@@ -1,4 +1,11 @@
+from io import BytesIO
 import re
+from typing import Optional
+from zipfile import ZipFile
+
+from PIL import Image, UnidentifiedImageError
+
+from ansimon_ai.ocr.from_ocr import ocr_image_to_result
 
 def _normalize_line(text: str) -> str:
     text = text.replace("\r", " ").replace("\n", " ")
@@ -17,7 +24,48 @@ def _dedupe_preserve_order(lines: list[str]) -> list[str]:
 
     return normalized_lines
 
-def extract_text_from_docx(docx_path: str) -> str:
+def _append_normalized_lines(lines: list[str], text: str) -> None:
+    for raw_line in text.splitlines():
+        normalized = _normalize_line(raw_line)
+        if normalized:
+            lines.append(normalized)
+
+def _extract_text_from_docx_images(
+    docx_path: str,
+    *,
+    engine: Optional[str] = None,
+    lang: str = "kor",
+) -> list[str]:
+    image_texts: list[str] = []
+    supported_suffixes = {".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff", ".webp"}
+
+    with ZipFile(docx_path) as archive:
+        image_names = sorted(
+            name
+            for name in archive.namelist()
+            if name.startswith("word/media/")
+            and any(name.lower().endswith(suffix) for suffix in supported_suffixes)
+        )
+
+        for image_name in image_names:
+            image_bytes = archive.read(image_name)
+            try:
+                with Image.open(BytesIO(image_bytes)) as image:
+                    result = ocr_image_to_result(image, engine=engine, lang=lang)
+            except (UnidentifiedImageError, OSError):
+                continue
+
+            if result.full_text.strip():
+                _append_normalized_lines(image_texts, result.full_text)
+
+    return image_texts
+
+def extract_text_from_docx(
+    docx_path: str,
+    *,
+    engine: Optional[str] = None,
+    lang: str = "kor",
+) -> str:
     from docx import Document
 
     document = Document(docx_path)
@@ -34,5 +82,13 @@ def extract_text_from_docx(docx_path: str) -> str:
             cells = [cell for cell in cells if cell]
             if cells:
                 lines.append(" | ".join(cells))
+
+    lines.extend(
+        _extract_text_from_docx_images(
+            docx_path,
+            engine=engine,
+            lang=lang,
+        )
+    )
 
     return "\n".join(_dedupe_preserve_order(lines))

--- a/tests/ocr/test_clova_ocr.py
+++ b/tests/ocr/test_clova_ocr.py
@@ -1,3 +1,5 @@
+from PIL import Image
+
 from ansimon_ai.ocr.clova_ocr import _parse_clova_ocr_response
 from ansimon_ai.ocr.layout import assign_speaker_sides
 from ansimon_ai.ocr.from_ocr import ocr_image_to_result
@@ -67,11 +69,26 @@ def test_ocr_image_to_result_uses_clova_when_engine_env_is_set(monkeypatch):
     monkeypatch.setenv("OCR_ENGINE", "clova")
     monkeypatch.setattr(
         "ansimon_ai.ocr.from_ocr.clova_ocr_image_to_result",
-        lambda image_path: expected,
+        lambda image_input: expected,
     )
 
     assert ocr_image_to_result("dummy.png") is expected
 
+def test_ocr_image_to_result_accepts_pil_image(monkeypatch):
+    expected = object()
+    image = Image.new("RGB", (8, 8), "white")
+
+    def fake_clova(image_input, *, lang="ko"):
+        assert isinstance(image_input, Image.Image)
+        assert lang == "ko"
+        return expected
+
+    monkeypatch.setattr(
+        "ansimon_ai.ocr.from_ocr.clova_ocr_image_to_result",
+        fake_clova,
+    )
+
+    assert ocr_image_to_result(image, engine="clova", lang="kor") is expected
 
 def test_ocr_segment_coordinate_properties():
     segment = OCRSegment(

--- a/tests/ocr/test_table_formatting.py
+++ b/tests/ocr/test_table_formatting.py
@@ -1,0 +1,207 @@
+import sys
+from types import SimpleNamespace
+
+from PIL import Image
+
+from ansimon_ai.ocr.clova_ocr import clova_ocr_image_to_result, _parse_clova_ocr_response
+from ansimon_ai.ocr.table_formatting import format_ocr_result_text, render_table_text
+from ansimon_ai.ocr.types import OCRResult, OCRSegment, OCRTable, OCRTableCell, OCRVertex
+
+
+def test_parse_clova_ocr_response_includes_tables() -> None:
+    result = _parse_clova_ocr_response(
+        {
+            "lang": "ko",
+            "images": [
+                {
+                    "fields": [
+                        {
+                            "inferText": "진료기록부",
+                            "lineBreak": True,
+                        }
+                    ],
+                    "tables": [
+                        {
+                            "cells": [
+                                {
+                                    "rowIndex": 0,
+                                    "columnIndex": 0,
+                                    "cellTextLines": [{"cellWords": [{"inferText": "진료일"}]}],
+                                },
+                                {
+                                    "rowIndex": 0,
+                                    "columnIndex": 1,
+                                    "cellTextLines": [{"cellWords": [{"inferText": "2025년 5월 4일"}]}],
+                                },
+                            ]
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert len(result.tables) == 1
+    assert result.tables[0].cells[0].text == "진료일"
+
+
+def test_clova_ocr_retries_without_table_detection_when_disabled(monkeypatch) -> None:
+    calls: list[bool] = []
+
+    class FakeHTTPError(Exception):
+        pass
+
+    class FakeResponse:
+        def __init__(self, status_code: int, payload: dict):
+            self.status_code = status_code
+            self._payload = payload
+            self.text = str(payload)
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise FakeHTTPError()
+
+        def json(self) -> dict:
+            return self._payload
+
+    def fake_post(_url, *, headers=None, json=None, timeout=None):
+        calls.append(bool(json.get("enableTableDetection")))
+        if len(calls) == 1:
+            return FakeResponse(
+                400,
+                {
+                    "code": "0028",
+                    "message": "Table detection disabled: Please activate the table extractor button.",
+                },
+            )
+
+        return FakeResponse(
+            200,
+            {
+                "lang": "ko",
+                "images": [{"fields": [{"inferText": "fallback ok", "lineBreak": True}]}],
+            },
+        )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        SimpleNamespace(post=fake_post, HTTPError=FakeHTTPError),
+    )
+
+    result = clova_ocr_image_to_result(
+        Image.new("RGB", (10, 10), "white"),
+        invoke_url="https://example.com/custom/v1/demo",
+        secret="secret",
+    )
+
+    assert calls == [True, False]
+    assert result.full_text == "fallback ok"
+
+
+def test_format_ocr_result_text_renders_tabular_segments_as_table() -> None:
+    result = OCRResult(
+        full_text="",
+        engine="clova:v2",
+        language="ko",
+        segments=[
+            OCRSegment(
+                text="약품명",
+                vertices=[
+                    OCRVertex(x=0, y=0),
+                    OCRVertex(x=30, y=0),
+                    OCRVertex(x=30, y=10),
+                    OCRVertex(x=0, y=10),
+                ],
+            ),
+            OCRSegment(
+                text="용량",
+                vertices=[
+                    OCRVertex(x=40, y=0),
+                    OCRVertex(x=70, y=0),
+                    OCRVertex(x=70, y=10),
+                    OCRVertex(x=40, y=10),
+                ],
+            ),
+            OCRSegment(
+                text="알프라졸람",
+                vertices=[
+                    OCRVertex(x=0, y=12),
+                    OCRVertex(x=30, y=12),
+                    OCRVertex(x=30, y=22),
+                    OCRVertex(x=0, y=22),
+                ],
+            ),
+            OCRSegment(
+                text="0.25mg",
+                vertices=[
+                    OCRVertex(x=40, y=12),
+                    OCRVertex(x=70, y=12),
+                    OCRVertex(x=70, y=22),
+                    OCRVertex(x=40, y=22),
+                ],
+            ),
+            OCRSegment(
+                text="치료 계획",
+                vertices=[
+                    OCRVertex(x=0, y=40),
+                    OCRVertex(x=80, y=40),
+                    OCRVertex(x=80, y=50),
+                    OCRVertex(x=0, y=50),
+                ],
+            ),
+        ],
+        tables=[
+            OCRTable(
+                cells=[
+                    OCRTableCell(
+                        text="약품명",
+                        row_index=0,
+                        column_index=0,
+                        vertices=[
+                            OCRVertex(x=0, y=0),
+                            OCRVertex(x=30, y=0),
+                            OCRVertex(x=30, y=10),
+                            OCRVertex(x=0, y=10),
+                        ],
+                    ),
+                    OCRTableCell(
+                        text="용량",
+                        row_index=0,
+                        column_index=1,
+                        vertices=[
+                            OCRVertex(x=40, y=0),
+                            OCRVertex(x=70, y=0),
+                            OCRVertex(x=70, y=10),
+                            OCRVertex(x=40, y=10),
+                        ],
+                    ),
+                    OCRTableCell(
+                        text="알프라졸람",
+                        row_index=1,
+                        column_index=0,
+                        vertices=[
+                            OCRVertex(x=0, y=12),
+                            OCRVertex(x=30, y=12),
+                            OCRVertex(x=30, y=22),
+                            OCRVertex(x=0, y=22),
+                        ],
+                    ),
+                    OCRTableCell(
+                        text="0.25mg",
+                        row_index=1,
+                        column_index=1,
+                        vertices=[
+                            OCRVertex(x=40, y=12),
+                            OCRVertex(x=70, y=12),
+                            OCRVertex(x=70, y=22),
+                            OCRVertex(x=40, y=22),
+                        ],
+                    ),
+                ]
+            )
+        ],
+    )
+
+    assert render_table_text(result.tables[0]) == "약품명 | 용량\n알프라졸람 | 0.25mg"
+    assert format_ocr_result_text(result) == "약품명 | 용량\n알프라졸람 | 0.25mg\n치료 계획"

--- a/tests/pdf/test_extract_image_pdf_tables.py
+++ b/tests/pdf/test_extract_image_pdf_tables.py
@@ -5,9 +5,8 @@ from PIL import Image
 
 sys.modules.setdefault("pdf2image", SimpleNamespace(convert_from_path=lambda *args, **kwargs: []))
 
-import ansimon_ai.pdf.extract_image_pdf as extract_image_pdf_module
-from ansimon_ai.ocr.types import OCRResult, OCRSegment, OCRTable, OCRTableCell, OCRVertex
-
+import ansimon_ai.pdf.extract_image_pdf as extract_image_pdf_module  # noqa: E402
+from ansimon_ai.ocr.types import OCRResult, OCRSegment, OCRTable, OCRTableCell, OCRVertex  # noqa: E402
 
 def test_extract_text_from_image_pdf_page_formats_table_output(monkeypatch) -> None:
     image = Image.new("RGB", (10, 10), "white")

--- a/tests/pdf/test_extract_image_pdf_tables.py
+++ b/tests/pdf/test_extract_image_pdf_tables.py
@@ -1,0 +1,80 @@
+import sys
+from types import SimpleNamespace
+
+from PIL import Image
+
+sys.modules.setdefault("pdf2image", SimpleNamespace(convert_from_path=lambda *args, **kwargs: []))
+
+import ansimon_ai.pdf.extract_image_pdf as extract_image_pdf_module
+from ansimon_ai.ocr.types import OCRResult, OCRSegment, OCRTable, OCRTableCell, OCRVertex
+
+
+def test_extract_text_from_image_pdf_page_formats_table_output(monkeypatch) -> None:
+    image = Image.new("RGB", (10, 10), "white")
+
+    monkeypatch.setattr(
+        extract_image_pdf_module,
+        "convert_from_path",
+        lambda _pdf_path, first_page=None, last_page=None: [image],
+    )
+    monkeypatch.setattr(
+        extract_image_pdf_module,
+        "ocr_image_to_result",
+        lambda image_input, *, engine=None, lang=None: OCRResult(
+            full_text="",
+            segments=[
+                OCRSegment(
+                    text="약품명",
+                    vertices=[
+                        OCRVertex(x=0, y=0),
+                        OCRVertex(x=10, y=0),
+                        OCRVertex(x=10, y=10),
+                        OCRVertex(x=0, y=10),
+                    ],
+                ),
+                OCRSegment(
+                    text="용량",
+                    vertices=[
+                        OCRVertex(x=12, y=0),
+                        OCRVertex(x=22, y=0),
+                        OCRVertex(x=22, y=10),
+                        OCRVertex(x=12, y=10),
+                    ],
+                ),
+            ],
+            language="ko",
+            engine="mock",
+            tables=[
+                OCRTable(
+                    cells=[
+                        OCRTableCell(
+                            text="약품명",
+                            row_index=0,
+                            column_index=0,
+                            vertices=[
+                                OCRVertex(x=0, y=0),
+                                OCRVertex(x=10, y=0),
+                                OCRVertex(x=10, y=10),
+                                OCRVertex(x=0, y=10),
+                            ],
+                        ),
+                        OCRTableCell(
+                            text="용량",
+                            row_index=0,
+                            column_index=1,
+                            vertices=[
+                                OCRVertex(x=12, y=0),
+                                OCRVertex(x=22, y=0),
+                                OCRVertex(x=22, y=10),
+                                OCRVertex(x=12, y=10),
+                            ],
+                        ),
+                    ]
+                )
+            ],
+        ),
+    )
+
+    text = extract_image_pdf_module.extract_text_from_image_pdf_page("sample.pdf", 0)
+
+    assert text == "약품명 | 용량"

--- a/tests/pdf/test_extract_text_auto.py
+++ b/tests/pdf/test_extract_text_auto.py
@@ -1,10 +1,12 @@
 import os
 import pytest
+from PIL import Image
 
 pytest.importorskip("pdfplumber")
 
 from ansimon_ai.pdf.extract_text_auto import extract_text_auto
 import ansimon_ai.pdf.extract_text_auto as extract_text_auto_module
+import ansimon_ai.pdf.extract_image_pdf as extract_image_pdf_module
 
 @pytest.mark.parametrize(
     "pdf_path",
@@ -37,13 +39,42 @@ def test_extract_text_auto_handles_mixed_pdf(monkeypatch):
     monkeypatch.setattr(
         extract_text_auto_module,
         "extract_text_from_image_pdf_page",
-        lambda _pdf_path, page_index, lang="kor": f"ocr-page-{page_index}-{lang}",
+        lambda _pdf_path, page_index, lang="kor", engine=None: f"ocr-page-{page_index}-{lang}-{engine}",
     )
 
-    texts = extract_text_auto("mixed.pdf")
+    texts = extract_text_auto("mixed.pdf", engine="clova")
 
     assert texts == [
         "text-page-0",
-        "ocr-page-1-kor",
+        "ocr-page-1-kor-clova",
         "text-page-2",
     ]
+
+def test_extract_text_from_image_pdf_page_uses_shared_ocr_runner(monkeypatch):
+    image = Image.new("RGB", (10, 10), "white")
+
+    monkeypatch.setattr(
+        extract_image_pdf_module,
+        "convert_from_path",
+        lambda _pdf_path, first_page=None, last_page=None: [image],
+    )
+
+    def fake_ocr_image_to_result(image_input, *, engine=None, lang=None):
+        assert image_input is image
+        assert engine == "clova"
+        assert lang == "kor"
+        return type("MockResult", (), {"full_text": "pdf-ocr-text"})()
+
+    monkeypatch.setattr(
+        extract_image_pdf_module,
+        "ocr_image_to_result",
+        fake_ocr_image_to_result,
+    )
+
+    text = extract_image_pdf_module.extract_text_from_image_pdf_page(
+        "sample.pdf",
+        0,
+        engine="clova",
+    )
+
+    assert text == "pdf-ocr-text"

--- a/tests/pdf/test_extract_text_auto.py
+++ b/tests/pdf/test_extract_text_auto.py
@@ -7,6 +7,7 @@ pytest.importorskip("pdfplumber")
 from ansimon_ai.pdf.extract_text_auto import extract_text_auto
 import ansimon_ai.pdf.extract_text_auto as extract_text_auto_module
 import ansimon_ai.pdf.extract_image_pdf as extract_image_pdf_module
+from ansimon_ai.ocr.types import OCRResult, OCRSegment
 
 @pytest.mark.parametrize(
     "pdf_path",
@@ -63,7 +64,12 @@ def test_extract_text_from_image_pdf_page_uses_shared_ocr_runner(monkeypatch):
         assert image_input is image
         assert engine == "clova"
         assert lang == "kor"
-        return type("MockResult", (), {"full_text": "pdf-ocr-text"})()
+        return OCRResult(
+            full_text="pdf-ocr-text",
+            segments=[OCRSegment(text="pdf-ocr-text")],
+            language="ko",
+            engine="mock",
+        )
 
     monkeypatch.setattr(
         extract_image_pdf_module,

--- a/tests/pdf/test_extract_text_docx.py
+++ b/tests/pdf/test_extract_text_docx.py
@@ -3,14 +3,13 @@ from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 from zipfile import ZipFile
-
 from PIL import Image
 
 import ansimon_ai.pdf.extract_text_docx as extract_text_docx_module
+from ansimon_ai.ocr.types import OCRResult, OCRSegment
 
 
 TEST_TMP_DIR = Path("data/_pdf_test_tmp")
-
 
 def _write_docx_with_images() -> Path:
     TEST_TMP_DIR.mkdir(parents=True, exist_ok=True)
@@ -25,7 +24,6 @@ def _write_docx_with_images() -> Path:
 
     return docx_path
 
-
 def test_extract_text_from_docx_images_uses_shared_ocr_runner(monkeypatch):
     docx_path = _write_docx_with_images()
 
@@ -33,7 +31,15 @@ def test_extract_text_from_docx_images_uses_shared_ocr_runner(monkeypatch):
         assert isinstance(image_input, Image.Image)
         assert engine == "clova"
         assert lang == "kor"
-        return SimpleNamespace(full_text="line one\nline two")
+        return OCRResult(
+            full_text="line one\nline two",
+            segments=[
+                OCRSegment(text="line one"),
+                OCRSegment(text="line two"),
+            ],
+            language="ko",
+            engine="mock",
+        )
 
     monkeypatch.setattr(
         extract_text_docx_module,
@@ -47,7 +53,6 @@ def test_extract_text_from_docx_images_uses_shared_ocr_runner(monkeypatch):
     )
 
     assert texts == ["line one", "line two"]
-
 
 def test_extract_text_from_docx_combines_text_table_and_image_ocr(monkeypatch):
     docx_path = _write_docx_with_images()
@@ -77,8 +82,11 @@ def test_extract_text_from_docx_combines_text_table_and_image_ocr(monkeypatch):
     monkeypatch.setattr(
         extract_text_docx_module,
         "ocr_image_to_result",
-        lambda image_input, *, engine=None, lang=None: SimpleNamespace(
-            full_text="image ocr text"
+        lambda image_input, *, engine=None, lang=None: OCRResult(
+            full_text="image ocr text",
+            segments=[OCRSegment(text="image ocr text")],
+            language="ko",
+            engine="mock",
         ),
     )
 

--- a/tests/pdf/test_extract_text_docx.py
+++ b/tests/pdf/test_extract_text_docx.py
@@ -1,0 +1,90 @@
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+from zipfile import ZipFile
+
+from PIL import Image
+
+import ansimon_ai.pdf.extract_text_docx as extract_text_docx_module
+
+
+TEST_TMP_DIR = Path("data/_pdf_test_tmp")
+
+
+def _write_docx_with_images() -> Path:
+    TEST_TMP_DIR.mkdir(parents=True, exist_ok=True)
+    docx_path = TEST_TMP_DIR / f"{uuid4()}-sample.docx"
+    image_buffer = BytesIO()
+    Image.new("RGB", (12, 12), "white").save(image_buffer, format="PNG")
+
+    with ZipFile(docx_path, "w") as archive:
+        archive.writestr("word/document.xml", "<document />")
+        archive.writestr("word/media/image1.png", image_buffer.getvalue())
+        archive.writestr("word/media/notes.txt", b"not-an-image")
+
+    return docx_path
+
+
+def test_extract_text_from_docx_images_uses_shared_ocr_runner(monkeypatch):
+    docx_path = _write_docx_with_images()
+
+    def fake_ocr_image_to_result(image_input, *, engine=None, lang=None):
+        assert isinstance(image_input, Image.Image)
+        assert engine == "clova"
+        assert lang == "kor"
+        return SimpleNamespace(full_text="line one\nline two")
+
+    monkeypatch.setattr(
+        extract_text_docx_module,
+        "ocr_image_to_result",
+        fake_ocr_image_to_result,
+    )
+
+    texts = extract_text_docx_module._extract_text_from_docx_images(
+        str(docx_path),
+        engine="clova",
+    )
+
+    assert texts == ["line one", "line two"]
+
+
+def test_extract_text_from_docx_combines_text_table_and_image_ocr(monkeypatch):
+    docx_path = _write_docx_with_images()
+
+    fake_document = SimpleNamespace(
+        paragraphs=[
+            SimpleNamespace(text="  first paragraph  "),
+            SimpleNamespace(text=""),
+        ],
+        tables=[
+            SimpleNamespace(
+                rows=[
+                    SimpleNamespace(
+                        cells=[
+                            SimpleNamespace(text="cell A"),
+                            SimpleNamespace(text="cell B"),
+                        ]
+                    )
+                ]
+            )
+        ],
+    )
+
+    fake_docx_module = SimpleNamespace(Document=lambda _path: fake_document)
+    monkeypatch.setitem(__import__("sys").modules, "docx", fake_docx_module)
+
+    monkeypatch.setattr(
+        extract_text_docx_module,
+        "ocr_image_to_result",
+        lambda image_input, *, engine=None, lang=None: SimpleNamespace(
+            full_text="image ocr text"
+        ),
+    )
+
+    text = extract_text_docx_module.extract_text_from_docx(
+        str(docx_path),
+        engine="clova",
+    )
+
+    assert text == "first paragraph\ncell A | cell B\nimage ocr text"


### PR DESCRIPTION
## 작업 내용
> PDF/DOCX 이미지가 포함된 문서에서도 Clova OCR 엔진 선택과 표 텍스트 추출이 가능하도록 문서 OCR 경로를 정리했습니다.

기존 PDF 처리 경로는 이미지 페이지를 만나면 Tesseract OCR 중심으로 동작하고 있어, 이미지 기반 PDF나 일부 페이지만 이미지인 혼합 PDF에서는 Clova OCR 품질 개선 효과를 활용하기 어려웠습니다.
이번 PR에서는 PDF 이미지 OCR 경로도 공용 OCR runner를 사용하도록 정리하고, 작업 중 함께 확인된 DOCX 내부 이미지 OCR 누락 케이스도 추가로 처리했습니다.

또한 이미지 안에 표가 포함된 경우 OCR 결과가 줄글처럼 풀려 증거 분석 단계에서 주요 정보가 흐려질 수 있어, Clova OCR table 응답을 파싱한 뒤 다음 타임라인 분석 단계에서 읽기 쉬운 텍스트 형태로 변환하도록 했습니다.

**주요 작업**
- PDF 이미지 OCR 경로에 공용 OCR runner 적용
- `extract_text_auto()`에서 이미지 PDF/혼합 PDF 이미지 페이지로 OCR 엔진 선택값 전달
- Clova OCR의 PIL 이미지 입력 처리 지원
- DOCX 내부 `word/media/*` 이미지 OCR 처리 추가
- Clova OCR table 응답 모델 및 파서 추가
- Clova OCR table 셀 정보를 문서 추출 텍스트에 반영
- Clova table detection 비활성화 응답 시 table detection 없이 재시도하는 fallback 추가
- PDF/DOCX 이미지 OCR 및 표 처리 테스트 추가

## 이슈 번호
#88 

## 스크린샷 (선택)
<img width="1241" height="712" alt="image" src="https://github.com/user-attachments/assets/925df82c-337b-4545-b5f8-1e80f82e1243" />

> DOCX 파일 테스트 결과

## 참고사항
- 이슈 본문에는 PDF 이미지 OCR 경로만 명시되어 있지만, 작업 중 DOCX 문서에도 이미지가 포함될 수 있는 누락 케이스를 확인하여 DOCX 이미지 OCR 처리도 함께 추가했습니다.